### PR TITLE
Ensure Drizzle migrations load env vars

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,11 +1,21 @@
+import { config as loadEnv } from 'dotenv'
+import { existsSync } from 'node:fs'
 import type { Config } from 'drizzle-kit'
+
+// Load environment variables so `drizzle-kit` has access to the database URL.
+// Prefer a local env file when present, otherwise fall back to `.env`.
+const envFile = existsSync('.env.local') ? '.env.local' : '.env'
+loadEnv({ path: envFile })
+
+const connectionString = process.env.DATABASE_URL
 
 export default {
   schema: './db/schema.ts',
   out: './drizzle',
   dialect: 'postgresql',
   dbCredentials: {
-    url: process.env.DATABASE_URL || '',
+    // Drizzle will error if the connection string is undefined.
+    url: connectionString!,
   },
 } satisfies Config
 


### PR DESCRIPTION
## Summary
- load `.env.local` or `.env` for Drizzle migration config

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `npm run db:migrate` *(fails: Can't find meta/_journal.json file)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b91fc7e8832db50bca5e8eb002b7