### PR TITLE
feat: add inbox frontend

### DIFF
--- a/app/inbox/page.tsx
+++ b/app/inbox/page.tsx
@@ -1,9 +1,5 @@
-export default function InboxPage() {
-  return (
-    <main className="p-6">
-      <h1 className="text-xl font-semibold">Inbox (MVP)</h1>
-      <p className="text-sm text-gray-500">Build UI to list conversations and messages.</p>
-    </main>
-  )
-}
+import { InboxPage } from '@/components/InboxPage'
 
+export default function Page() {
+  return <InboxPage />
+}

--- a/components/InboxPage.tsx
+++ b/components/InboxPage.tsx
@@ -1,0 +1,106 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { Conversation, Message, ApiListResponse } from '@/lib/types'
+
+async function fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(url, options)
+  if (!res.ok) {
+    throw new Error(`Request failed: ${res.status}`)
+  }
+  return (await res.json()) as T
+}
+
+export function InboxPage() {
+  const [conversations, setConversations] = useState<Conversation[]>([])
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [messages, setMessages] = useState<Message[]>([])
+  const [text, setText] = useState('')
+
+  useEffect(() => {
+    fetchJson<ApiListResponse<Conversation>>('/api/inbox/conversations')
+      .then((data) => setConversations(data.data))
+      .catch(() => setConversations([]))
+  }, [])
+
+  useEffect(() => {
+    if (!selectedId) return
+    fetchJson<ApiListResponse<Message>>(`/api/inbox/conversations/${selectedId}/messages`)
+      .then((data) => setMessages(data.data))
+      .catch(() => setMessages([]))
+  }, [selectedId])
+
+  const sendMessage = async () => {
+    if (!selectedId || !text.trim()) return
+    await fetchJson<{ message: Message }>(
+      `/api/inbox/conversations/${selectedId}/messages`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text }),
+      },
+    ).then((data) => {
+      setMessages((prev) => [...prev, data.message])
+      setText('')
+    })
+  }
+
+  return (
+    <main className="p-6 flex gap-4">
+      <aside className="w-64 border-r">
+        <h2 className="font-semibold mb-2">Conversations</h2>
+        <ul className="space-y-1">
+          {conversations.map((c) => (
+            <li key={c.id}>
+              <button
+                type="button"
+                onClick={() => setSelectedId(c.id)}
+                className={`block w-full text-left px-2 py-1 rounded ${
+                  selectedId === c.id ? 'bg-gray-200' : 'hover:bg-gray-100'
+                }`}
+              >
+                {c.psid}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </aside>
+      <section className="flex-1 flex flex-col">
+        {selectedId ? (
+          <>
+            <div className="flex-1 overflow-y-auto mb-4 space-y-2">
+              {messages.map((m) => (
+                <div
+                  key={m.id}
+                  className={`flex ${
+                    m.direction === 'outbound' ? 'justify-end' : 'justify-start'
+                  }`}
+                >
+                  <div className="px-2 py-1 rounded bg-gray-200">{m.text}</div>
+                </div>
+              ))}
+            </div>
+            <div className="flex gap-2">
+              <input
+                value={text}
+                onChange={(e) => setText(e.target.value)}
+                className="flex-1 border rounded px-2 py-1"
+                placeholder="Type a message"
+              />
+              <button
+                type="button"
+                onClick={sendMessage}
+                className="px-3 py-1 rounded bg-blue-600 text-white disabled:opacity-50"
+                disabled={!text.trim()}
+              >
+                Send
+              </button>
+            </div>
+          </>
+        ) : (
+          <p>Select a conversation to view messages.</p>
+        )}
+      </section>
+    </main>
+  )
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,32 @@
+export interface Conversation {
+  id: string;
+  tenantId: string;
+  pageId: string;
+  psid: string;
+  lastMessageAt: string;
+  unreadCount: number;
+  assigneeUserId: string | null;
+  status: string;
+}
+
+export type MessageDirection = 'inbound' | 'outbound';
+
+export interface Message {
+  id: string;
+  conversationId: string;
+  direction: MessageDirection;
+  mid: string;
+  text: string | null;
+  attachmentsJson: string | null;
+  timestamp: string;
+  deliveryState: string | null;
+  readAt: string | null;
+}
+
+export interface ApiListResponse<T> {
+  data: T[];
+}
+
+export interface ApiItemResponse<T> {
+  data: T;
+}


### PR DESCRIPTION
## Summary
- add typed shared API models for conversations and messages
- implement inbox page fetching conversations and messages and sending messages
- hook up /inbox page to new component

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any in existing files)
- `npx eslint components/InboxPage.tsx app/inbox/page.tsx lib/types.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b2c422356c832da0c72dbdeca79255