### PR TITLE
feat: add shadcn navbar

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { ThemeProvider } from "@/components/theme-provider";
+import { Navbar } from "@/components/Navbar";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -23,6 +24,7 @@ export default function RootLayout({
             enableSystem
             disableTransitionOnChange
           >
+            <Navbar />
             {children}
           </ThemeProvider>
         </body>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import { ModeToggle } from "@/components/ModeToggle"
+
+export function Navbar() {
+  return (
+    <nav className="border-b">
+      <div className="container mx-auto flex h-14 items-center px-4">
+        <Link href="/" className="font-semibold">
+          FB Messenger
+        </Link>
+        <div className="ml-auto flex items-center gap-2">
+          <Button variant="ghost" asChild>
+            <Link href="/connections">Connections</Link>
+          </Button>
+          <Button variant="ghost" asChild>
+            <Link href="/inbox">Inbox</Link>
+          </Button>
+          <ModeToggle />
+        </div>
+      </div>
+    </nav>
+  )
+}


### PR DESCRIPTION
## Summary
- add a ShadCN-based Navbar component with links and theme toggle
- render the new Navbar in the root layout

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any. Specify a different type)


------
https://chatgpt.com/codex/tasks/task_e_68b2cd05a064832d9684cbb524fc3974