### PR TITLE
docs: add privacy policy

### DIFF
--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -1,0 +1,38 @@
+# Privacy Policy for FB Business Messenger
+
+_Last updated: 2025-08-31_
+
+We respect your privacy. This policy describes how FB Business Messenger ("we," "our," or "us") collects, uses, and safeguards information when you use our Facebook application and related services.
+
+## Information We Collect
+- **Account information**: Data from your Facebook account such as name, profile picture, and page access tokens when you authorize the app.
+- **Messaging data**: Content of messages, attachments, and metadata exchanged through the app.
+- **Usage information**: Logs, analytics, and device data related to how you interact with the service.
+
+## How We Use Information
+We use collected data to:
+- Provide and improve messaging features
+- Authenticate users and manage sessions
+- Respond to inquiries and support requests
+- Comply with legal obligations and enforce our policies
+
+## Data Sharing
+We do not sell your personal information. We may share data with:
+- **Service providers** assisting with hosting, analytics, or support, under confidentiality obligations
+- **Facebook** as required to operate with their APIs and services
+- **Law enforcement** when legally compelled or to protect our rights
+
+## Data Retention
+We retain information only as long as necessary to provide our services and fulfill the purposes described above. You may request deletion of your data at any time by contacting us.
+
+## Security
+We implement administrative, technical, and physical safeguards designed to protect information from unauthorized access and disclosure.
+
+## Your Rights
+Depending on your location, you may have rights to access, correct, or delete your personal data. Contact us to exercise these rights.
+
+## Contact Us
+If you have questions or concerns about this policy, contact us at **privacy@example.com**.
+
+Using FB Business Messenger signifies your acceptance of this Privacy Policy. We may update this policy from time to time. Continued use after updates constitutes acceptance.
+


### PR DESCRIPTION
## Summary
- add privacy policy for FB Business Messenger app

## Testing
- `npm run lint` *(fails: Unexpected any errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68b45a3d4f88832d950b16e84e9bd69d