### PR TITLE
Fix message route params and add message status ticks

### DIFF
--- a/components/InboxPage.tsx
+++ b/components/InboxPage.tsx
@@ -87,7 +87,18 @@ export function InboxPage() {
                     m.direction === 'outbound' ? 'justify-end' : 'justify-start'
                   }`}
                 >
-                  <div className="px-2 py-1 rounded bg-gray-200">{m.text}</div>
+                  <div className="px-2 py-1 rounded bg-gray-200 flex items-end gap-1">
+                    {m.text}
+                    {m.direction === 'outbound' && (
+                      <span
+                        className={`text-xs ${
+                          m.readAt ? 'text-blue-500' : 'text-gray-500'
+                        }`}
+                      >
+                        {m.readAt ? '✓✓' : '✓'}
+                      </span>
+                    )}
+                  </div>
                 </div>
               ))}
             </div>

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -3,7 +3,7 @@ import { Worker, QueueEvents } from 'bullmq'
 import { redis } from '@/lib/redis'
 import { db } from '@/db'
 import { conversations, facebookConnections, messages } from '@/db/schema'
-import { and, eq, sql } from 'drizzle-orm'
+import { and, eq, sql, lte } from 'drizzle-orm'
 import { Emitter } from '@socket.io/redis-emitter'
 import crypto from 'crypto'
 
@@ -44,79 +44,109 @@ async function upsertFromEntry(entry: any) {
     return
   }
 
-  // Only persist messages for actual 'message' events
-  if (kind !== 'message' || !mid) {
-    console.log('worker:skip_non_message', { kind, pageId })
-    return
-  }
-
-  // Upsert conversation by (tenantId, pageId, psid)
-  const convId = crypto.randomUUID()
-  const now = new Date(messaging.timestamp || Date.now())
-  // Insert if missing; otherwise do nothing
-  await db
-    .insert(conversations)
-    .values({
-      id: convId,
-      tenantId: conn.tenantId,
-      pageId,
-      psid,
-      lastMessageAt: now,
-      unreadCount: 1,
-      status: 'open',
-    })
-    .onConflictDoNothing({ target: [conversations.tenantId, conversations.pageId, conversations.psid] })
-
-  // Always update lastMessageAt and increment unreadCount
-  await db
-    .update(conversations)
-    .set({
-      lastMessageAt: now,
-      unreadCount: sql`"conversations"."unread_count" + 1`,
-    })
-    .where(
-      and(
-        eq(conversations.tenantId, conn.tenantId),
-        eq(conversations.pageId, pageId),
-        eq(conversations.psid, psid)
-      )
-    )
-
-  const conversation = (
+  if (kind === 'message' && mid) {
+    // Upsert conversation by (tenantId, pageId, psid)
+    const convId = crypto.randomUUID()
+    const now = new Date(messaging.timestamp || Date.now())
+    // Insert if missing; otherwise do nothing
     await db
-      .select()
-      .from(conversations)
-      .where(and(eq(conversations.tenantId, conn.tenantId), eq(conversations.pageId, pageId), eq(conversations.psid, psid)))
-      .limit(1)
-  )[0]
-  if (!conversation) {
-    console.error('worker:conversation_upsert_missing', { tenantId: conn.tenantId, pageId, psid })
+      .insert(conversations)
+      .values({
+        id: convId,
+        tenantId: conn.tenantId,
+        pageId,
+        psid,
+        lastMessageAt: now,
+        unreadCount: 1,
+        status: 'open',
+      })
+      .onConflictDoNothing({ target: [conversations.tenantId, conversations.pageId, conversations.psid] })
+
+    // Always update lastMessageAt and increment unreadCount
+    await db
+      .update(conversations)
+      .set({
+        lastMessageAt: now,
+        unreadCount: sql`"conversations"."unread_count" + 1`,
+      })
+      .where(
+        and(
+          eq(conversations.tenantId, conn.tenantId),
+          eq(conversations.pageId, pageId),
+          eq(conversations.psid, psid)
+        )
+      )
+
+    const conversation = (
+      await db
+        .select()
+        .from(conversations)
+        .where(and(eq(conversations.tenantId, conn.tenantId), eq(conversations.pageId, pageId), eq(conversations.psid, psid)))
+        .limit(1)
+    )[0]
+    if (!conversation) {
+      console.error('worker:conversation_upsert_missing', { tenantId: conn.tenantId, pageId, psid })
+      return
+    }
+
+    // Upsert message by mid
+    const messageId = crypto.randomUUID()
+    await db
+      .insert(messages)
+      .values({
+        id: messageId,
+        conversationId: conversation.id,
+        direction: 'inbound',
+        mid,
+        text,
+        timestamp: now,
+      })
+      .onConflictDoNothing({ target: messages.mid })
+
+    const message = (
+      await db.select().from(messages).where(eq(messages.mid, mid)).limit(1)
+    )[0]
+
+    // Emit realtime event to tenant and page rooms
+    emitter
+      .to(`tenant:${conversation.tenantId}`)
+      .to(`page:${pageId}`)
+      .emit('message:new', { conversationId: conversation.id, message })
     return
   }
 
-  // Upsert message by mid
-  const messageId = crypto.randomUUID()
-  await db
-    .insert(messages)
-    .values({
-      id: messageId,
-      conversationId: conversation.id,
-      direction: 'inbound',
-      mid,
-      text,
-      timestamp: now,
-    })
-    .onConflictDoNothing({ target: messages.mid })
+  if (kind === 'read') {
+    const watermark = messaging.read?.watermark
+    if (!watermark) {
+      console.log('worker:skip_read_no_watermark', { pageId })
+      return
+    }
+    const readAt = new Date(watermark)
+    const conversation = (
+      await db
+        .select()
+        .from(conversations)
+        .where(and(eq(conversations.tenantId, conn.tenantId), eq(conversations.pageId, pageId), eq(conversations.psid, psid)))
+        .limit(1)
+    )[0]
+    if (!conversation) {
+      console.warn('worker:read_conversation_missing', { tenantId: conn.tenantId, pageId, psid })
+      return
+    }
+    await db
+      .update(messages)
+      .set({ readAt, deliveryState: 'seen' })
+      .where(
+        and(
+          eq(messages.conversationId, conversation.id),
+          eq(messages.direction, 'outbound'),
+          lte(messages.timestamp, readAt)
+        )
+      )
+    return
+  }
 
-  const message = (
-    await db.select().from(messages).where(eq(messages.mid, mid)).limit(1)
-  )[0]
-
-  // Emit realtime event to tenant and page rooms
-  emitter
-    .to(`tenant:${conversation.tenantId}`)
-    .to(`page:${pageId}`)
-    .emit('message:new', { conversationId: conversation.id, message })
+  console.log('worker:skip_unhandled', { kind, pageId })
 }
 
 export const worker = new Worker(


### PR DESCRIPTION
## Summary
- fix messages API route to await dynamic params and record sent status
- show sent/seen ticks for outbound messages in inbox UI
- handle read webhook events to mark messages as seen

## Testing
- `npm run lint` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d46bf5c0832d88ed927e9d12f271