### PR TITLE
fix: guard page token before unpacking

### DIFF
--- a/components/InboxPage.tsx
+++ b/components/InboxPage.tsx
@@ -71,27 +71,27 @@ export function InboxPage() {
 
       // Fetch profile info if missing
       (async () => {
-        try {
-          if (!conversation.name || !conversation.profilePic) {
-            const token = decrypt(unpack(conversation.pageTokenEnc));
-            const profile = await getUserProfile(conversation.psid, token);
-            setConversations((prev) =>
-              prev.map((c) =>
-                c.id === conversation.id
-                  ? {
-                      ...c,
-                      name: profile.name,
-                      profilePic: profile.picture?.data?.url,
-                    }
-                  : c
-              )
-            );
+          try {
+            if ((!conversation.name || !conversation.profilePic) && conversation.pageTokenEnc) {
+              const token = decrypt(unpack(conversation.pageTokenEnc));
+              const profile = await getUserProfile(conversation.psid, token);
+              setConversations((prev) =>
+                prev.map((c) =>
+                  c.id === conversation.id
+                    ? {
+                        ...c,
+                        name: profile.name,
+                        profilePic: profile.picture?.data?.url,
+                      }
+                    : c
+                )
+              );
+            }
+          } catch (err) {
+            console.error("Failed to fetch profile", err);
           }
-        } catch (err) {
-          console.error("Failed to fetch profile", err);
-        }
-      })();
-    }
+        })();
+      }
 
     socket.on('message:new', handleMessageNew)
 

--- a/lib/crypto.ts
+++ b/lib/crypto.ts
@@ -36,7 +36,10 @@ export function pack(enc: { iv: string; tag: string; data: string }) {
   return Buffer.from(JSON.stringify(enc)).toString('base64')
 }
 
-export function unpack(blob: string) {
+export function unpack(blob: string | null | undefined) {
+  if (!blob) {
+    throw new TypeError('Cannot unpack empty payload')
+  }
   return JSON.parse(Buffer.from(blob, 'base64').toString('utf8')) as {
     iv: string
     tag: string


### PR DESCRIPTION
## Summary
- avoid unpacking undefined page tokens on new messages
- validate input for `unpack` to prevent runtime errors

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8350e5cf4832d88356924dc3c1ff2