### PR TITLE
fix: guard page token before unpacking

### DIFF
--- a/app/api/inbox/conversations/[id]/token/route.ts
+++ b/app/api/inbox/conversations/[id]/token/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server'
+import { db } from '@/db'
+import { conversations as convs, facebookConnections } from '@/db/schema'
+import { eq, and } from 'drizzle-orm'
+
+export async function GET(
+  _req: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params
+  const conv = (
+    await db.select().from(convs).where(eq(convs.id, id)).limit(1)
+  )[0]
+  if (!conv) {
+    return NextResponse.json({ error: 'not_found' }, { status: 404 })
+  }
+  const conn = (
+    await db
+      .select()
+      .from(facebookConnections)
+      .where(
+        and(
+          eq(facebookConnections.tenantId, conv.tenantId),
+          eq(facebookConnections.pageId, conv.pageId),
+        ),
+      )
+      .limit(1)
+  )[0]
+  if (!conn) {
+    return NextResponse.json({ error: 'no_connection' }, { status: 400 })
+  }
+  return NextResponse.json({ data: { pageTokenEnc: conn.pageTokenEnc } })
+}

--- a/lib/crypto.ts
+++ b/lib/crypto.ts
@@ -36,7 +36,10 @@ export function pack(enc: { iv: string; tag: string; data: string }) {
   return Buffer.from(JSON.stringify(enc)).toString('base64')
 }
 
-export function unpack(blob: string) {
+export function unpack(blob: string | null | undefined) {
+  if (!blob) {
+    throw new TypeError('Cannot unpack empty payload')
+  }
   return JSON.parse(Buffer.from(blob, 'base64').toString('utf8')) as {
     iv: string
     tag: string

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -7,7 +7,6 @@ export interface Conversation {
   unreadCount: number;
   assigneeUserId: string | null;
   status: string;
-  pageTokenEnc: string; // encrypted page access token
   name?: string;
   profilePic?: string;
 }


### PR DESCRIPTION
## Summary
- remove page token from conversation type
- fetch encrypted page token from DB when profile details are missing
- add API endpoint to expose page token for a conversation

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8350e5cf4832d88356924dc3c1ff2