### PR TITLE
feat: list connected pages with inbox links

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,57 +1,6 @@
 import NextAuth from 'next-auth'
-import Credentials from 'next-auth/providers/credentials'
-import { db } from '@/db'
-import { users } from '@/db/schema'
-import { eq } from 'drizzle-orm'
-import bcrypt from 'bcrypt'
+import { authOptions } from '@/lib/auth'
 
-const handler = NextAuth({
-  session: { strategy: 'jwt' },
-  providers: [
-    Credentials({
-      name: 'Credentials',
-      credentials: {
-        email: { label: 'Email', type: 'email' },
-        password: { label: 'Password', type: 'password' },
-      },
-      async authorize(credentials) {
-        if (!credentials?.email || !credentials.password) return null
-        const found = await db.select().from(users).where(eq(users.email, credentials.email)).limit(1)
-        const user = found[0]
-        if (!user) return null
-        const ok = await bcrypt.compare(credentials.password, user.passwordHash)
-        if (!ok) return null
-        return { id: user.id, email: user.email, tenantId: user.tenantId, role: user.role }
-      },
-    }),
-  ],
-  callbacks: {
-    async jwt({ token, user }) {
-      if (user) {
-        const u = user as {
-          id: string
-          tenantId: string
-          role: string
-        }
-        token.userId = u.id
-        token.tenantId = u.tenantId
-        token.role = u.role
-      }
-      return token
-    },
-    async session({ session, token }) {
-      const s = session as typeof session & {
-        userId?: string
-        tenantId?: string
-        role?: string
-      }
-      s.userId = token.userId as string | undefined
-      s.tenantId = token.tenantId as string | undefined
-      s.role = token.role as string | undefined
-      return s
-    },
-  },
-  secret: process.env.NEXTAUTH_SECRET,
-})
+const handler = NextAuth(authOptions)
 
 export { handler as GET, handler as POST }

--- a/app/inbox/page.tsx
+++ b/app/inbox/page.tsx
@@ -1,5 +1,13 @@
 import { InboxPage } from '@/components/InboxPage'
 
-export default function Page() {
-  return <InboxPage />
+export default function Page({
+  searchParams,
+}: {
+  searchParams: { tenantId?: string; pageId?: string }
+}) {
+  const { tenantId, pageId } = searchParams
+  if (!tenantId || !pageId) {
+    return <div className="p-6">Missing pageId or tenantId</div>
+  }
+  return <InboxPage tenantId={tenantId} pageId={pageId} />
 }

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -13,9 +13,6 @@ export function Navbar() {
           <Button variant="ghost" asChild>
             <Link href="/connections">Connections</Link>
           </Button>
-          <Button variant="ghost" asChild>
-            <Link href="/inbox">Inbox</Link>
-          </Button>
           <ModeToggle />
         </div>
       </div>

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, integer, timestamp, uniqueIndex, primaryKey } from 'drizzle-orm/pg-core'
+import { pgTable, text, integer, timestamp, uniqueIndex } from 'drizzle-orm/pg-core'
 
 export const tenants = pgTable('tenants', {
   id: text('id').primaryKey(),

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,55 @@
+import { NextAuthOptions } from 'next-auth'
+import Credentials from 'next-auth/providers/credentials'
+import { db } from '@/db'
+import { users } from '@/db/schema'
+import { eq } from 'drizzle-orm'
+import bcrypt from 'bcrypt'
+
+export const authOptions: NextAuthOptions = {
+  session: { strategy: 'jwt' },
+  providers: [
+    Credentials({
+      name: 'Credentials',
+      credentials: {
+        email: { label: 'Email', type: 'email' },
+        password: { label: 'Password', type: 'password' },
+      },
+      async authorize(credentials) {
+        if (!credentials?.email || !credentials.password) return null
+        const found = await db
+          .select()
+          .from(users)
+          .where(eq(users.email, credentials.email))
+          .limit(1)
+        const user = found[0]
+        if (!user) return null
+        const ok = await bcrypt.compare(credentials.password, user.passwordHash)
+        if (!ok) return null
+        return { id: user.id, email: user.email, tenantId: user.tenantId, role: user.role }
+      },
+    }),
+  ],
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) {
+        const u = user as { id: string; tenantId: string; role: string }
+        token.userId = u.id
+        token.tenantId = u.tenantId
+        token.role = u.role
+      }
+      return token
+    },
+    async session({ session, token }) {
+      const s = session as typeof session & {
+        userId?: string
+        tenantId?: string
+        role?: string
+      }
+      s.userId = token.userId as string | undefined
+      s.tenantId = token.tenantId as string | undefined
+      s.role = token.role as string | undefined
+      return s
+    },
+  },
+  secret: process.env.NEXTAUTH_SECRET,
+}


### PR DESCRIPTION
## Summary
- list all tenant connections with per-page inbox buttons
- require tenantId and pageId for inbox conversation queries
- drop Inbox link from navbar and share NextAuth options

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b86e658dfc832d890260202f7b80c1