### PR TITLE
fix: wrap theme context in client providers

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,7 @@
 import type { Metadata } from "next";
 import "@/styles/globals.css";
-import { ThemeProvider } from "@/components/theme-provider";
 import { Navbar } from "@/components/Navbar";
-import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
-import { AppSidebar } from "@/components/app-sidebar";
-import { SessionProvider } from "next-auth/react";
+import { Providers } from "./providers";
 
 export const metadata: Metadata = {
   title: "FB Business Messenger",
@@ -21,28 +18,12 @@ export default function RootLayout({
       <html lang="en" suppressHydrationWarning>
         <head />
         <body className="tw-bg-gray-50 dark:tw-bg-gray-900">
-          <ThemeProvider
-            attribute="class"
-            defaultTheme="system"
-            enableSystem
-            disableTransitionOnChange
-          >
-            <SessionProvider>
-              <SidebarProvider>
-                <Navbar />
-                <div className="tw-container tw-min-h-screen tw-mx-auto tw-mt-4 tw-bg-white dark:tw-bg-gray-800 tw-rounded-lg tw-shadow-md tw-p-4">
-                  {children}
-                </div>
-              </SidebarProvider>
-            </SessionProvider>
-            {/* <SidebarProvider>
-              <AppSidebar />
-              <main>
-                <SidebarTrigger />
-                {children}
-              </main>
-            </SidebarProvider> */}
-          </ThemeProvider>
+          <Providers>
+            <Navbar />
+            <div className="tw-container tw-min-h-screen tw-mx-auto tw-mt-4 tw-bg-white dark:tw-bg-gray-800 tw-rounded-lg tw-shadow-md tw-p-4">
+              {children}
+            </div>
+          </Providers>
         </body>
       </html>
     </>

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import * as React from "react";
+import { ThemeProvider } from "@/components/theme-provider";
+import { SessionProvider } from "next-auth/react";
+import { SidebarProvider } from "@/components/ui/sidebar";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <ThemeProvider
+      attribute="class"
+      defaultTheme="system"
+      enableSystem
+      disableTransitionOnChange
+    >
+      <SessionProvider>
+        <SidebarProvider>{children}</SidebarProvider>
+      </SessionProvider>
+    </ThemeProvider>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add dedicated client-side Providers component to manage theme, session, and sidebar contexts
- use Providers in root layout to keep React context out of server components

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b978794698832d82c4439e99d0d203