### PR TITLE
Store tenant in session

### DIFF
--- a/app/connections/page.tsx
+++ b/app/connections/page.tsx
@@ -1,13 +1,10 @@
 import { ConnectionsPage } from '@/components/ConnectionsPage'
+import { getServerSession } from 'next-auth/next'
+import { authOptions } from '@/lib/auth'
 
-interface PageProps {
-  searchParams: Promise<{
-    tenantId?: string
-  }>
-}
-
-export default async function Page({ searchParams }: PageProps) {
-  const { tenantId } = await searchParams
+export default async function Page() {
+  const session = await getServerSession(authOptions)
+  const tenantId = session?.tenantId
 
   if (!tenantId) {
     return <div className="p-6">Missing tenantId</div>;

--- a/components/ConnectionsPage.tsx
+++ b/components/ConnectionsPage.tsx
@@ -2,22 +2,16 @@ import Link from 'next/link'
 import { db } from '@/db'
 import { facebookConnections } from '@/db/schema'
 import { eq } from 'drizzle-orm'
-import { getServerSession } from 'next-auth/next'
-import { authOptions } from '@/lib/auth'
 
 interface ConnectionsPageProps {
-  tenantId?: string
+  tenantId: string
 }
 
 export async function ConnectionsPage({ tenantId }: ConnectionsPageProps) {
-  const session = await getServerSession(authOptions)
-  const effectiveTenantId = tenantId ?? session?.tenantId
-  const connections = effectiveTenantId
-    ? await db
-        .select()
-        .from(facebookConnections)
-        .where(eq(facebookConnections.tenantId, effectiveTenantId))
-    : []
+  const connections = await db
+    .select()
+    .from(facebookConnections)
+    .where(eq(facebookConnections.tenantId, tenantId))
 
   return (
     <main className="p-6 max-w-3xl mx-auto space-y-4">

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,4 +1,4 @@
-import { NextAuthOptions } from 'next-auth'
+import { NextAuthOptions, Session } from 'next-auth'
 import Credentials from 'next-auth/providers/credentials'
 import { db } from '@/db'
 import { users } from '@/db/schema'
@@ -40,7 +40,7 @@ export const authOptions: NextAuthOptions = {
       return token
     },
     async session({ session, token }) {
-      const s = session as typeof session & {
+      const s = session as Session & {
         userId?: string
         tenantId?: string
         role?: string
@@ -48,6 +48,11 @@ export const authOptions: NextAuthOptions = {
       s.userId = token.userId as string | undefined
       s.tenantId = token.tenantId as string | undefined
       s.role = token.role as string | undefined
+      if (s.user) {
+        if (s.userId) s.user.id = s.userId
+        if (s.tenantId) s.user.tenantId = s.tenantId
+        if (s.role) s.user.role = s.role
+      }
       return s
     },
   },

--- a/next-auth.d.ts
+++ b/next-auth.d.ts
@@ -1,8 +1,18 @@
-import { DefaultSession } from 'next-auth'
+import { DefaultSession, DefaultUser } from 'next-auth'
 import { DefaultJWT } from 'next-auth/jwt'
 
 declare module 'next-auth' {
+  interface User extends DefaultUser {
+    tenantId: string
+    role: string
+  }
+
   interface Session extends DefaultSession {
+    user: DefaultSession['user'] & {
+      id: string
+      tenantId: string
+      role: string
+    }
     userId?: string
     tenantId?: string
     role?: string


### PR DESCRIPTION
## Summary
- Attach user, tenant, and role details to the NextAuth session
- Read tenant ID from session in connections page
- Simplify ConnectionsPage component to rely on provided tenant ID

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9938c3af4832db9a99c60dbea6292