### PR TITLE
feat: add database clear script

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,12 @@ SEED_USER_PASSWORD=change-me
 
 This script is for local/dev usage only.
 
+To remove all data from the database during development:
+
+```bash
+npm run db:clear
+```
+
 5) Start the app
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
+    "db:clear": "tsx ./scripts/clear-db.ts",
     "worker": "tsx ./worker/index.ts"
   },
   "dependencies": {

--- a/scripts/clear-db.ts
+++ b/scripts/clear-db.ts
@@ -1,0 +1,37 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { config as loadEnv } from 'dotenv'
+import { sql } from 'drizzle-orm'
+
+async function main() {
+  const envLocal = path.resolve(process.cwd(), '.env.local')
+  if (fs.existsSync(envLocal)) {
+    loadEnv({ path: envLocal })
+  } else {
+    loadEnv()
+  }
+
+  const { db } = await import('../db')
+
+  await db.execute(sql`
+    TRUNCATE TABLE
+      messages,
+      conversations,
+      facebook_connections,
+      user_roles,
+      permissions,
+      permission_categories,
+      roles,
+      webhook_events,
+      users,
+      tenants
+    RESTART IDENTITY CASCADE
+  `)
+
+  console.log('Cleared all data from database')
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- add script to truncate all database tables
- expose `npm run db:clear` for development resets
- document database clearing in README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb35f07fd8832d995083753d62afc8