### PR TITLE
feat: add user role management

### DIFF
--- a/app/api/tenants/[tenantId]/users/[userRoleId]/route.ts
+++ b/app/api/tenants/[tenantId]/users/[userRoleId]/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { db } from "@/db";
+import { users, userRoles } from "@/db/schema";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+import { userHasPermission } from "@/lib/permissions";
+
+const schema = z.object({
+  email: z.string().email(),
+  roleName: z.string().min(1),
+});
+
+export async function PUT(
+  req: Request,
+  { params }: { params: { tenantId: string; userRoleId: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { tenantId, userRoleId } = params;
+  const allowed = await userHasPermission(
+    session.userId,
+    tenantId,
+    "manage_users"
+  );
+  if (!allowed) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const body = await req.json().catch(() => null);
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid data" }, { status: 400 });
+  }
+  if (parsed.data.roleName === "owner") {
+    return NextResponse.json({ error: "Invalid role" }, { status: 400 });
+  }
+  const existing = (
+    await db.select().from(users).where(eq(users.email, parsed.data.email)).limit(1)
+  )[0];
+  await db
+    .update(userRoles)
+    .set({
+      roleName: parsed.data.roleName,
+      email: parsed.data.email,
+      userId: existing?.id,
+      status: existing ? "active" : "pending",
+    })
+    .where(
+      and(eq(userRoles.id, userRoleId), eq(userRoles.tenantId, tenantId))
+    );
+  return NextResponse.json({ data: { id: userRoleId } });
+}

--- a/app/api/tenants/[tenantId]/users/route.ts
+++ b/app/api/tenants/[tenantId]/users/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { db } from "@/db";
+import { users, userRoles } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import crypto from "node:crypto";
+import { userHasPermission } from "@/lib/permissions";
+
+const schema = z.object({
+  email: z.string().email(),
+  roleName: z.string().min(1),
+});
+
+export async function POST(
+  req: Request,
+  { params }: { params: { tenantId: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { tenantId } = params;
+  const allowed = await userHasPermission(
+    session.userId,
+    tenantId,
+    "manage_users"
+  );
+  if (!allowed) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const body = await req.json().catch(() => null);
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid data" }, { status: 400 });
+  }
+  if (parsed.data.roleName === "owner") {
+    return NextResponse.json({ error: "Invalid role" }, { status: 400 });
+  }
+  const existing = (
+    await db.select().from(users).where(eq(users.email, parsed.data.email)).limit(1)
+  )[0];
+  const id = crypto.randomUUID();
+  await db.insert(userRoles).values({
+    id,
+    roleName: parsed.data.roleName,
+    tenantId,
+    userId: existing?.id,
+    email: parsed.data.email,
+    status: existing ? "active" : "pending",
+  });
+  return NextResponse.json({ data: { id } }, { status: 201 });
+}

--- a/app/app/[tenantId]/users/add/page.tsx
+++ b/app/app/[tenantId]/users/add/page.tsx
@@ -1,9 +1,0 @@
-import React from 'react'
-
-const page = () => {
-  return (
-    <div>Add User</div>
-  )
-}
-
-export default page

--- a/app/app/[tenantId]/users/page.tsx
+++ b/app/app/[tenantId]/users/page.tsx
@@ -1,9 +1,47 @@
-import React from 'react'
+import { db } from "@/db";
+import { roles, userRoles } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { UserRoleDialog } from "@/components/user-role-dialog";
 
-const page = () => {
+export default async function Page({ params }: { params: { tenantId: string } }) {
+  const { tenantId } = params;
+  const roleRows = await db
+    .select({ name: roles.name })
+    .from(roles)
+    .where(eq(roles.tenantId, tenantId));
+  const userRows = await db
+    .select({ id: userRoles.id, email: userRoles.email, roleName: userRoles.roleName, status: userRoles.status })
+    .from(userRoles)
+    .where(eq(userRoles.tenantId, tenantId));
+  const roleNames = roleRows.map((r) => r.name).filter((n) => n !== "owner");
+  const users = userRows.filter((u) => u.roleName !== "owner");
   return (
-    <div>List Users</div>
-  )
+    <main className="p-6 max-w-3xl mx-auto space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-semibold">Users</h1>
+        <UserRoleDialog tenantId={tenantId} roles={roleNames} />
+      </div>
+      <ul className="space-y-2">
+        {users.map((u) => (
+          <li
+            key={u.id}
+            className="flex items-center justify-between border dark:border-gray-700 rounded p-2"
+          >
+            <div>
+              <div className="font-medium">{u.email}</div>
+              <div className="text-xs text-gray-500">
+                {u.roleName} · {u.status}
+              </div>
+            </div>
+            <UserRoleDialog
+              tenantId={tenantId}
+              roles={roleNames}
+              userRole={u}
+              trigger={<button className="underline">Edit</button>}
+            />
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
 }
-
-export default page

--- a/components/user-role-dialog.tsx
+++ b/components/user-role-dialog.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState, ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { UserRoleForm } from "@/components/user-role-form";
+
+interface UserRoleDialogProps {
+  tenantId: string;
+  roles: string[];
+  userRole?: { id: string; email: string; roleName: string };
+  trigger?: ReactNode;
+}
+
+export function UserRoleDialog({ tenantId, roles, userRole, trigger }: UserRoleDialogProps) {
+  const [open, setOpen] = useState(false);
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        {trigger ?? <Button>Add User</Button>}
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{userRole ? "Update User" : "Add User"}</DialogTitle>
+        </DialogHeader>
+        <UserRoleForm
+          tenantId={tenantId}
+          roles={roles}
+          userRole={userRole}
+          onSuccess={() => setOpen(false)}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/user-role-form.tsx
+++ b/components/user-role-form.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from "@/components/ui/form";
+
+const schema = z.object({
+  email: z.string().email(),
+  roleName: z.string().min(1),
+});
+
+interface UserRoleFormProps {
+  tenantId: string;
+  roles: string[];
+  userRole?: { id: string; email: string; roleName: string };
+  onSuccess?: () => void;
+}
+
+export function UserRoleForm({ tenantId, roles, userRole, onSuccess }: UserRoleFormProps) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const form = useForm<z.infer<typeof schema>>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      email: userRole?.email ?? "",
+      roleName: userRole?.roleName ?? roles[0] ?? "",
+    },
+  });
+
+  async function onSubmit(values: z.infer<typeof schema>) {
+    setError(null);
+    const res = await fetch(
+      userRole
+        ? `/api/tenants/${tenantId}/users/${userRole.id}`
+        : `/api/tenants/${tenantId}/users`,
+      {
+        method: userRole ? "PUT" : "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(values),
+      }
+    );
+    if (!res.ok) {
+      const data = await res.json().catch(() => null);
+      setError(data?.error || "Request failed");
+      return;
+    }
+    router.refresh();
+    onSuccess?.();
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Email</FormLabel>
+              <FormControl>
+                <Input type="email" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="roleName"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Role</FormLabel>
+              <FormControl>
+                <select
+                  className="border rounded px-2 py-2 w-full bg-transparent"
+                  {...field}
+                >
+                  {roles.map((r) => (
+                    <option key={r} value={r}>
+                      {r}
+                    </option>
+                  ))}
+                </select>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        {error && <p className="text-sm text-red-500">{error}</p>}
+        <Button type="submit">{userRole ? "Update" : "Add"} User</Button>
+      </form>
+    </Form>
+  );
+}


### PR DESCRIPTION
## Summary
- list tenant users by user roles excluding owners
- add/update tenant users through reusable dialog with zod validation
- create API endpoints to manage tenant user roles and set status based on existing users

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb49970a48832dacdda48b2f9765b5