### PR TITLE
feat: handle pending roles and improve user list

### DIFF
--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -7,6 +7,7 @@ import { tenants, userRoles, permissions } from "@/db/schema";
 import { eq, and, inArray } from "drizzle-orm";
 import { TenantActions } from "@/components/tenant-actions";
 import { TenantCreateDialog } from "@/components/tenant-create-dialog";
+import { PendingRoleActions } from "@/components/pending-role-actions";
 import { BriefcaseBusiness } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 
@@ -20,6 +21,7 @@ export default async function Home() {
     .select({
       id: tenants.id,
       name: tenants.name,
+      roleId: userRoles.id,
       roleName: userRoles.roleName,
       roleStatus: userRoles.status,
     })
@@ -67,12 +69,16 @@ export default async function Home() {
               <Badge variant={"outline"}>{t.roleName}</Badge>
               <Badge variant={"outline"}>{t.roleStatus}</Badge>
             </Link>
-            <TenantActions
-              tenantId={t.id}
-              tenantName={t.name}
-              canEdit={canEdit.has(t.id)}
-              canDelete={canDelete.has(t.id)}
-            />
+            {t.roleStatus === "pending" ? (
+              <PendingRoleActions roleId={t.roleId} />
+            ) : (
+              <TenantActions
+                tenantId={t.id}
+                tenantName={t.name}
+                canEdit={canEdit.has(t.id)}
+                canDelete={canDelete.has(t.id)}
+              />
+            )}
           </div>
         ))}
       </div>

--- a/app/api/user-roles/[userRoleId]/route.ts
+++ b/app/api/user-roles/[userRoleId]/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { db } from "@/db";
+import { userRoles } from "@/db/schema";
+import { eq } from "drizzle-orm";
+
+export async function PATCH(
+  _req: Request,
+  { params }: { params: { userRoleId: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.userId || !session.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { userRoleId } = params;
+  const role = (
+    await db
+      .select()
+      .from(userRoles)
+      .where(eq(userRoles.id, userRoleId))
+      .limit(1)
+  )[0];
+  if (!role) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  if (role.email !== session.email) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  await db
+    .update(userRoles)
+    .set({ status: "active", userId: session.userId })
+    .where(eq(userRoles.id, userRoleId));
+  return NextResponse.json({ data: { id: userRoleId } });
+}
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: { userRoleId: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { userRoleId } = params;
+  const role = (
+    await db
+      .select()
+      .from(userRoles)
+      .where(eq(userRoles.id, userRoleId))
+      .limit(1)
+  )[0];
+  if (!role) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  if (role.email !== session.email) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  await db.delete(userRoles).where(eq(userRoles.id, userRoleId));
+  return NextResponse.json({ data: { id: userRoleId } });
+}
+

--- a/app/app/[tenantId]/users/page.tsx
+++ b/app/app/[tenantId]/users/page.tsx
@@ -2,6 +2,7 @@ import { db } from "@/db";
 import { roles, userRoles } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { UserRoleDialog } from "@/components/user-role-dialog";
+import { Badge } from "@/components/ui/badge";
 
 export default async function Page({ params }: { params: { tenantId: string } }) {
   const { tenantId } = params;
@@ -21,27 +22,35 @@ export default async function Page({ params }: { params: { tenantId: string } })
         <h1 className="text-xl font-semibold">Users</h1>
         <UserRoleDialog tenantId={tenantId} roles={roleNames} />
       </div>
-      <ul className="space-y-2">
-        {users.map((u) => (
-          <li
-            key={u.id}
-            className="flex items-center justify-between border dark:border-gray-700 rounded p-2"
-          >
-            <div>
-              <div className="font-medium">{u.email}</div>
-              <div className="text-xs text-gray-500">
-                {u.roleName} · {u.status}
-              </div>
-            </div>
-            <UserRoleDialog
-              tenantId={tenantId}
-              roles={roleNames}
-              userRole={u}
-              trigger={<button className="underline">Edit</button>}
-            />
-          </li>
-        ))}
-      </ul>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b dark:border-gray-700 text-left">
+              <th className="py-2">Email</th>
+              <th className="py-2">Role</th>
+              <th className="py-2">Status</th>
+              <th className="py-2 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y dark:divide-gray-700">
+            {users.map((u) => (
+              <tr key={u.id}>
+                <td className="py-2 font-medium">{u.email}</td>
+                <td className="py-2 capitalize">{u.roleName}</td>
+                <td className="py-2"><Badge variant="outline" className="capitalize">{u.status}</Badge></td>
+                <td className="py-2 text-right">
+                  <UserRoleDialog
+                    tenantId={tenantId}
+                    roles={roleNames}
+                    userRole={u}
+                    trigger={<button className="underline">Edit</button>}
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </main>
   );
 }

--- a/components/pending-role-actions.tsx
+++ b/components/pending-role-actions.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+
+export function PendingRoleActions({ roleId }: { roleId: string }) {
+  const router = useRouter();
+  async function activate() {
+    const res = await fetch(`/api/user-roles/${roleId}`, { method: "PATCH" });
+    if (res.ok) {
+      router.refresh();
+    }
+  }
+  async function cancel() {
+    const res = await fetch(`/api/user-roles/${roleId}`, { method: "DELETE" });
+    if (res.ok) {
+      router.refresh();
+    }
+  }
+  return (
+    <div className="flex gap-2">
+      <Button size="sm" onClick={activate}>Activate</Button>
+      <Button size="sm" variant="outline" onClick={cancel}>
+        Cancel
+      </Button>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- allow users to activate or cancel pending roles from home page
- add API endpoints to accept or delete pending role invitations
- restyle tenant user list with table layout

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb51c9302c832da537980e8a1f1712