### PR TITLE
feat: add permission checks to pages

### DIFF
--- a/app/app/[tenantId]/connections/page.tsx
+++ b/app/app/[tenantId]/connections/page.tsx
@@ -3,12 +3,12 @@ import { ConnectionsPage } from '@/components/ConnectionsPage'
 import { getServerSession } from 'next-auth/next'
 import { authOptions } from '@/lib/auth'
 import { redirect } from "next/navigation";
+import { userHasPermission } from "@/lib/permissions";
 
 export default async function Page({ params }: { params: { tenantId: string } }) {
-  const { tenantId } = await params;
+  const { tenantId } = params;
 
   const session = await getServerSession(authOptions);
-
   if (!session) {
     redirect("/login");
   }
@@ -17,6 +17,17 @@ export default async function Page({ params }: { params: { tenantId: string } })
     return <div className="p-6">Missing tenantId</div>;
   }
 
-  return <ConnectionsPage tenantId={tenantId} />;
+  const canView = session.userId
+    ? await userHasPermission(session.userId, tenantId, "view_connections")
+    : false;
+  if (!canView) {
+    return <div className="p-6">Forbidden</div>;
+  }
+
+  const canConnect = session.userId
+    ? await userHasPermission(session.userId, tenantId, "manage_users")
+    : false;
+
+  return <ConnectionsPage tenantId={tenantId} canConnect={canConnect} />;
 }
 

--- a/components/ConnectionsPage.tsx
+++ b/components/ConnectionsPage.tsx
@@ -6,9 +6,10 @@ import { Badge } from '@/components/ui/badge'
 
 interface ConnectionsPageProps {
   tenantId: string
+  canConnect: boolean
 }
 
-export async function ConnectionsPage({ tenantId }: ConnectionsPageProps) {
+export async function ConnectionsPage({ tenantId, canConnect }: ConnectionsPageProps) {
   const connections = await db
     .select()
     .from(facebookConnections)
@@ -22,12 +23,14 @@ export async function ConnectionsPage({ tenantId }: ConnectionsPageProps) {
       <p className="text-sm text-gray-500">
         Connect your Facebook Page to start receiving messages.
       </p>
-      <a
-        href={`/api/meta/login`}
-        className="inline-flex items-center px-4 py-2 rounded-md bg-blue-600 text-white hover:bg-blue-700"
-      >
-        {connections.length > 0 ? "Reconnect" : "Connect"} Facebook Pages
-      </a>
+      {canConnect && (
+        <a
+          href={`/api/meta/login`}
+          className="inline-flex items-center px-4 py-2 rounded-md bg-blue-600 text-white hover:bg-blue-700"
+        >
+          {connections.length > 0 ? "Reconnect" : "Connect"} Facebook Pages
+        </a>
+      )}
       <ul className="space-y-2">
         {connections.map((conn) => (
           <li


### PR DESCRIPTION
## Summary
- restrict user management features to roles with `manage_users`
- limit viewing connections and inbox access via permission checks
- show Facebook connect button only for admins and owners

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb58084a78832d81c79fd29d77ce39