### PR TITLE
Fix redirects behind proxies by honoring forwarded host headers

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -13,20 +13,31 @@ export async function middleware(req: NextRequest) {
     const parts = pathname.split("/");
     const tenantId = parts[2];
     const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
+
+    // Respect forwarded headers so redirects work behind tunnels/proxies
+    // (e.g., localtunnel). Fall back to the request's own origin.
+    const proto =
+      req.headers.get("x-forwarded-proto") ?? req.nextUrl.protocol.replace(":", "");
+    const host =
+      req.headers.get("x-forwarded-host") ?? req.headers.get("host") ?? "";
+    const origin = `${proto}://${host}`;
+
     if (!token?.userId || typeof tenantId !== "string") {
-      // Use original request origin so redirects respect proxied hosts
-      // (e.g., localtunnel or other reverse proxies).
-      const loginUrl = new URL("/login", req.nextUrl.origin);
+      const loginUrl = new URL("/login", origin);
       return NextResponse.redirect(loginUrl);
     }
     const rows = await db
       .select({ id: userRoles.id })
       .from(userRoles)
-      .where(and(eq(userRoles.userId, token.userId as string), eq(userRoles.tenantId, tenantId)))
+      .where(
+        and(
+          eq(userRoles.userId, token.userId as string),
+          eq(userRoles.tenantId, tenantId)
+        )
+      )
       .limit(1);
     if (!rows.length) {
-      // Preserve forwarded origin for consistent redirects behind proxies.
-      const rootUrl = new URL("/", req.nextUrl.origin);
+      const rootUrl = new URL("/", origin);
       return NextResponse.redirect(rootUrl);
     }
   }


### PR DESCRIPTION
## Summary
- Use `x-forwarded-proto` and `x-forwarded-host` headers in middleware redirect URLs to support tunnels like localtunnel

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb64f6ad68832da00bfd1cc2471193