### PR TITLE
feat: manage facebook page connections

### DIFF
--- a/app/api/tenants/[tenantId]/connections/[connectionId]/route.ts
+++ b/app/api/tenants/[tenantId]/connections/[connectionId]/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { db } from "@/db";
+import { facebookConnections } from "@/db/schema";
+import { and, eq } from "drizzle-orm";
+import { userHasPermission } from "@/lib/permissions";
+import { unpack, decrypt } from "@/lib/crypto";
+import { unsubscribePage } from "@/lib/meta";
+
+export async function DELETE(
+  req: Request,
+  { params }: { params: { tenantId: string; connectionId: string } },
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { tenantId, connectionId } = params;
+  const allowed = await userHasPermission(
+    session.userId,
+    tenantId,
+    "manage_users",
+  );
+  if (!allowed) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const [conn] = await db
+    .select()
+    .from(facebookConnections)
+    .where(
+      and(
+        eq(facebookConnections.id, connectionId),
+        eq(facebookConnections.tenantId, tenantId),
+      ),
+    )
+    .limit(1);
+  if (!conn) {
+    return NextResponse.json({ error: "Not Found" }, { status: 404 });
+  }
+  try {
+    const token = decrypt(unpack(conn.pageTokenEnc));
+    await unsubscribePage(conn.pageId, token);
+  } catch {
+    // ignore unsubscribe errors
+  }
+  await db
+    .delete(facebookConnections)
+    .where(
+      and(
+        eq(facebookConnections.id, connectionId),
+        eq(facebookConnections.tenantId, tenantId),
+      ),
+    );
+  return NextResponse.json({ data: { id: connectionId } });
+}

--- a/components/ConnectionsPage.tsx
+++ b/components/ConnectionsPage.tsx
@@ -3,6 +3,7 @@ import { db } from '@/db'
 import { facebookConnections } from '@/db/schema'
 import { eq } from 'drizzle-orm'
 import { Badge } from '@/components/ui/badge'
+import { ConnectionDeleteButton } from '@/components/connection-delete-button'
 
 interface ConnectionsPageProps {
   tenantId: string
@@ -43,12 +44,20 @@ export async function ConnectionsPage({ tenantId, canConnect }: ConnectionsPageP
                 Tenant: {conn.tenantId}
               </div>
             </div>
-            <Link
-              className="underline"
-              href={`/app/${tenantId}/connections/${conn.id}/inbox`}
-            >
-              Inbox
-            </Link>
+            <div className="flex items-center gap-2">
+              <Link
+                className="underline"
+                href={`/app/${tenantId}/connections/${conn.id}/inbox`}
+              >
+                Inbox
+              </Link>
+              {canConnect && (
+                <ConnectionDeleteButton
+                  tenantId={tenantId}
+                  connectionId={conn.id}
+                />
+              )}
+            </div>
           </li>
         ))}
       </ul>

--- a/components/connection-delete-button.tsx
+++ b/components/connection-delete-button.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+
+interface ConnectionDeleteButtonProps {
+  tenantId: string;
+  connectionId: string;
+}
+
+export function ConnectionDeleteButton({
+  tenantId,
+  connectionId,
+}: ConnectionDeleteButtonProps) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+
+  async function onDelete() {
+    setLoading(true);
+    await fetch(`/api/tenants/${tenantId}/connections/${connectionId}`, {
+      method: "DELETE",
+    });
+    setLoading(false);
+    router.refresh();
+  }
+
+  return (
+    <Button
+      variant="destructive"
+      size="sm"
+      onClick={onDelete}
+      disabled={loading}
+    >
+      Delete
+    </Button>
+  );
+}

--- a/lib/meta.ts
+++ b/lib/meta.ts
@@ -52,6 +52,13 @@ export async function subscribePage(pageId: string, pageAccessToken: string) {
   return data
 }
 
+export async function unsubscribePage(pageId: string, pageAccessToken: string) {
+  const { data } = await axios.delete(`${API}/${pageId}/subscribed_apps`, {
+    headers: { Authorization: `Bearer ${pageAccessToken}` },
+  })
+  return data
+}
+
 export async function sendMessage(
   pageId: string,
   pageAccessToken: string,


### PR DESCRIPTION
## Summary
- ignore existing page connections in Meta callback and skip subscription
- allow tenants to remove page connections with proper permission checks
- add delete button to connections list for managing subscriptions

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc0cee8870832db11cf0a16b6da537