### PR TITLE
fix: enable realtime inbox updates

### DIFF
--- a/components/InboxPage.tsx
+++ b/components/InboxPage.tsx
@@ -67,6 +67,10 @@ export function InboxPage({
   // WebSocket setup and cleanup on mount/unmount
   useEffect(() => {
     socketRef.current = socket
+    // Join tenant and page rooms for realtime updates
+    if (tenantId && pageId) {
+      socket.emit('join', [`tenant:${tenantId}`, `page:${pageId}`])
+    }
 
     const handleMessageNew = ({
       conversationId,


### PR DESCRIPTION
## Summary
- join tenant and page rooms on socket connection so InboxPage receives realtime messages

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc1fc00aec832d9f7cd22592095c74