### PR TITLE
Render message attachments in inbox

### DIFF
--- a/components/InboxPage.tsx
+++ b/components/InboxPage.tsx
@@ -7,6 +7,7 @@ import type {
   Message,
   ApiListResponse,
   ApiItemResponse,
+  MessageAttachment,
 } from '@/lib/types'
 import Image from 'next/image';
 import { getUserProfile } from "@/lib/meta";
@@ -201,29 +202,72 @@ export function InboxPage({
           {selectedId ? (
             <>
               <div className="flex-1 overflow-y-auto mb-4 space-y-2 h-[75vh]">
-                {messages.map((m) => (
-                  <div
-                    key={m.id}
-                    className={`flex ${
-                      m.direction === "outbound"
-                        ? "justify-end"
-                        : "justify-start"
-                    }`}
-                  >
-                    <div className="px-2 py-1 rounded bg-gray-200 dark:bg-gray-700 flex items-end gap-1">
-                      {m.text}
-                      {m.direction === "outbound" && (
-                        <span
-                          className={`text-xs ${
-                            m.readAt ? "text-blue-500" : "text-gray-500"
-                          }`}
-                        >
-                          {m.readAt ? "✓✓" : "✓"}
-                        </span>
-                      )}
+                {messages.map((m) => {
+                  const attachments: MessageAttachment[] = m.attachmentsJson
+                    ? JSON.parse(m.attachmentsJson)
+                    : []
+                  return (
+                    <div
+                      key={m.id}
+                      className={`flex ${
+                        m.direction === "outbound"
+                          ? "justify-end"
+                          : "justify-start"
+                      }`}
+                    >
+                      <div className="px-2 py-1 rounded bg-gray-200 dark:bg-gray-700 flex flex-col gap-1 max-w-xs">
+                        {m.text && <span>{m.text}</span>}
+                        {attachments.map((a, idx) => {
+                          if (a.type === "image" || a.type === "sticker") {
+                            return (
+                              <Image
+                                key={idx}
+                                src={a.payload?.url || ''}
+                                alt={a.type}
+                                width={200}
+                                height={200}
+                                className="rounded"
+                              />
+                            )
+                          }
+                          if (a.type === "audio") {
+                            return <audio key={idx} controls src={a.payload?.url} />
+                          }
+                          if (a.type === "video") {
+                            return (
+                              <video
+                                key={idx}
+                                controls
+                                src={a.payload?.url}
+                                className="max-w-full rounded"
+                              />
+                            )
+                          }
+                          return (
+                            <a
+                              key={idx}
+                              href={a.payload?.url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="underline"
+                            >
+                              {a.type} attachment
+                            </a>
+                          )
+                        })}
+                        {m.direction === "outbound" && (
+                          <span
+                            className={`text-xs self-end ${
+                              m.readAt ? "text-blue-500" : "text-gray-500"
+                            }`}
+                          >
+                            {m.readAt ? "✓✓" : "✓"}
+                          </span>
+                        )}
+                      </div>
                     </div>
-                  </div>
-                ))}
+                  )
+                })}
                 <div ref={messagesEndRef} />
               </div>
               <div className="flex gap-2 items-center">

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -35,6 +35,14 @@ export interface Message {
   readAt: string | null;
 }
 
+export interface MessageAttachment {
+  type: string;
+  payload?: {
+    url?: string;
+    sticker_id?: string;
+  };
+}
+
 export interface ApiListResponse<T> {
   data: T[];
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -22,6 +22,10 @@ const nextConfig: NextConfig = {
         protocol: "https",
         hostname: "i.pravatar.cc",
       },
+      {
+        protocol: "https",
+        hostname: "**.fbcdn.net",
+      },
     ],
   },
 };


### PR DESCRIPTION
## Summary
- support images, audio, video and other attachments in inbox messages
- persist attachment metadata from webhook worker
- allow fbcdn images in Next.js config

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc4fac90a8832d818f574f18f37967