### PR TITLE
fix: enable cdn gif attachments

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -17,14 +17,17 @@ const nextConfig: NextConfig = {
       {
         protocol: "https",
         hostname: "cdn.fbsbx.com",
+        pathname: "/**",
       },
       {
         protocol: "https",
         hostname: "i.pravatar.cc",
+        pathname: "/**",
       },
       {
         protocol: "https",
         hostname: "**.fbcdn.net",
+        pathname: "/**",
       },
     ],
   },


### PR DESCRIPTION
## Summary
- allow GIF and sticker CDN URLs by specifying pathname wildcard in image remote patterns

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc5db96d54832d85761dac155a6351