### PR TITLE
Handle fallback URL attachments in inbox

### DIFF
--- a/components/InboxPage.tsx
+++ b/components/InboxPage.tsx
@@ -251,6 +251,37 @@ export function InboxPage({
                               />
                             )
                           }
+                          if (a.type === "fallback") {
+                            const rawUrl = a.payload?.url;
+                            if (!rawUrl) return null;
+                            let finalUrl = rawUrl;
+                            try {
+                              const parsed = new URL(rawUrl);
+                              if (
+                                parsed.hostname === "l.facebook.com" &&
+                                parsed.searchParams.has("u")
+                              ) {
+                                finalUrl =
+                                  decodeURIComponent(
+                                    parsed.searchParams.get("u") || rawUrl,
+                                  );
+                              }
+                            } catch {
+                              /* ignore parse errors */
+                            }
+                            const label = a.payload?.title || finalUrl;
+                            return (
+                              <a
+                                key={idx}
+                                href={finalUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="underline"
+                              >
+                                {label}
+                              </a>
+                            );
+                          }
                           return (
                             <a
                               key={idx}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -39,6 +39,7 @@ export interface MessageAttachment {
   type: string;
   payload?: {
     url?: string;
+    title?: string;
     sticker_id?: string;
     animated_url?: string;
   };


### PR DESCRIPTION
## Summary
- render Messenger "fallback" attachments with a decoded link and title in the inbox UI
- extend `MessageAttachment` payload to include an optional `title`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc6c863d48832dba2308f590b027aa